### PR TITLE
reformat

### DIFF
--- a/src/examples/water_absorption.py
+++ b/src/examples/water_absorption.py
@@ -3,7 +3,6 @@ from pyscf import gto, scf, dft
 import rt_scf
 from rt_spec import abs_spec
 from rt_vapp import ElectricField
-from rt_parse import parse
 
 mol = gto.M(
 	verbose = 0,
@@ -19,7 +18,7 @@ mf = dft.RKS(mol)
 mf.xc = 'PBE0'
 mf.kernel()
 
-rt_mf = rt_scf.RT_SCF(mf, 0.2, 1, 1000, 'water_abs')
+rt_mf = rt_scf.RT_SCF(mf, 0.2, 1, 1000)
 rt_mf.observables.update(dipole=True)
 
 delta_field = ElectricField('delta', [0.0001, 0.0001, 0.0001])
@@ -28,7 +27,12 @@ rt_mf.add_potential(delta_field)
 
 rt_mf.kernel()
 
-parse(rt_mf)
-time = rt_mf.dipole[:,0]
-dipole_xyz = rt_mf.dipole[:,1:]
+time = rt_mf.time
+dipole_xyz = rt_mf.dipole
+xdip = np.vstack((rt_mf.time, rt_mf.dipole[:, 0])).T
+ydip = np.vstack((rt_mf.time, rt_mf.dipole[:, 1])).T
+zdip = np.vstack((rt_mf.time, rt_mf.dipole[:, 2])).T
+np.savetxt("xdip.txt", xdip)
+np.savetxt("ydip.txt", ydip)
+np.savetxt("zdip.txt", zdip)
 abs_spec(time, dipole_xyz, 'water_abs_values', 0.0001, 50000, 50) # Zero-pad and exponential damping for clean spectrum

--- a/src/examples/water_dimer_icd.py
+++ b/src/examples/water_dimer_icd.py
@@ -43,20 +43,18 @@ water2.kernel()
 # Calculate noscf basis to print orbital occupations in
 noscf_orbitals = basis_utils.noscfbasis(dimer, water1, water2)
 
-rt_water = rt_scf.RT_SCF(dimer,1,1,1500,"H2OH2O")
-
+rt_water = rt_scf.RT_SCF(dimer,1,1,1500)
 # Declare which observables to be calculated/printed
-rt_water.observables.update(mo_occ=True, charge=True, energy=True)
-rt_water.prop = 'magnus_step'
+rt_water.observables.update(energy=True, mo_occ=True, charge=True)
 
 # Create object for complex absorbing potential and add to rt object
 CAP = MOCAP(0.5, 0.0477, 1.0, 10.0, dimer.get_ovlp())
 rt_water.add_potential(CAP)
 
 # Remove electron from 4th molecular orbital (in SCF basis)
-# Declare the two water fragments for their charge to be calculated
+# Input the two water fragments for their charge to be calculated
 rt_utils.excite(rt_water, 4)
-rt_utils.input_fragments(rt_water, range(0,3),range(3,6))
+rt_utils.input_fragments(rt_water, water1, water2)
 
 # Start calculation, send in noscf_orbitals to print
 rt_water.kernel(mo_coeff_print=noscf_orbitals)

--- a/src/rt_observables.py
+++ b/src/rt_observables.py
@@ -45,10 +45,9 @@ def get_observables(rt_mf, mo_coeff_print):
 def get_energy(rt_mf, den_ao, *args):
     energy = []
     energy.append(rt_mf._scf.energy_tot(dm=den_ao))
-    for i, mask in enumerate(rt_mf.fragments_indices):
-        frag = rt_mf.fragments[i]
+    for frag, mask in rt_mf.fragments.items():
         energy.append(frag.energy_tot(dm=den_ao[mask]))
-    
+
     rt_mf.energy.append(energy)
 
 def get_charge(rt_mf, den_ao, *args):
@@ -56,11 +55,11 @@ def get_charge(rt_mf, den_ao, *args):
     charge = []
     if rt_mf.nmat == 2:
         charge.append(np.trace(np.sum(np.matmul(den_ao,rt_mf.ovlp), axis=0)))
-        for _, mask in enumerate(rt_mf.fragments_indices):
+        for frag, mask in rt_mf.fragments.items():
             charge.append(np.trace(np.sum(np.matmul(den_ao,rt_mf.ovlp)[mask], axis=0)))
     else:
         charge.append(np.trace(np.matmul(den_ao,rt_mf.ovlp)))
-        for _, mask in enumerate(rt_mf.fragments_indices):
+        for frag, mask in rt_mf.fragments.items():
             charge.append(np.trace(np.matmul(den_ao,rt_mf.ovlp)[mask]))
     
     rt_mf.charge.append(charge)
@@ -81,8 +80,7 @@ def get_mo_occ(rt_mf, den_ao, mo_coeff_print, *args):
 def get_dipole(rt_mf, den_ao, *args):
     dipole = []
     dipole.append(rt_mf._scf.dip_moment(rt_mf._scf.mol, rt_mf.den_ao,'A.U.', 1))
-    for i, mask in enumerate(rt_mf.fragments_indices):
-        frag = rt_mf.fragments[i]
+    for frag, mask in rt_mf.fragments.items():
         dipole.append(frag.dip_moment(frag.mol, den_ao[mask], 'A.U.', 1))
     
     rt_mf.dipole.append(dipole)
@@ -96,7 +94,7 @@ def get_mag(rt_mf, den_ao, *args):
     magz = np.sum((den_ao[:Nsp, :Nsp] - den_ao[Nsp:, Nsp:]) * rt_mf.ovlp[:Nsp,:Nsp])
     mag.append([magx, magy, magz])
 
-    for i, mask in enumerate(rt_mf.fragments_indices):
+    for frag, mask in rt_mf.fragments.items():
         frag_ovlp = rt_mf.ovlp[mask]
         frag_den_ao = den_ao[mask]
         Nsp = int(np.shape(frag_ovlp)[0] / 2)

--- a/src/rt_scf_prop.py
+++ b/src/rt_scf_prop.py
@@ -13,7 +13,7 @@ def propagate(rt_mf, mo_coeff_print):
 
     integrate_function = rt_integrators.get_integrator(rt_mf)
     if rt_mf.prop == "magnus_step":
-        rt_mf.mo_coeff_old = rt_mf._scf.mo_coeff
+        rt_mf.mo_coeff_orth_old = rt_mf.rotate_coeff_to_orth(rt_mf._scf.mo_coeff)
     if rt_mf.prop == "magnus_interpol":
         rt_mf.fock_orth_n12dt = rt_mf.get_fock_orth(rt_mf.den_ao)
         if not hasattr(rt_mf, 'magnus_tolerance'): rt_mf.magnus_tolerance = 1e-7

--- a/src/rt_utils.py
+++ b/src/rt_utils.py
@@ -26,15 +26,14 @@ def input_fragments(rt_mf, *fragments):
 
     nmo = rt_mf._scf.mol.nao_nr()
     for index, frag in enumerate(fragments):
-        rt_mf.fragments.append(frag)
         match_indices = match_fragment_atom(rt_mf._scf, frag)
         mask_basis = mask_fragment_basis(rt_mf._scf, match_indices)
-        rt_mf.fragments_indices.append(mask_basis)
+        rt_mf.fragments[frag] = mask_basis
 
 def restart_from_chkfile(rt_mf):
     with open(rt_mf.chkfile, 'r') as f:
         chk_lines = f.readlines()
-        rt_mf.current_time = np.float64(chk_lines[0].split()[3])
+        rt_mf.current_time = float(chk_lines[0].split()[3])
         if rt_mf.nmat == 1:
             rt_mf._scf.mo_coeff = np.loadtxt(chk_lines[2:], dtype=np.complex128)
         else:


### PR DESCRIPTION
moved ao->oao mo_coeff rotation to class defined method for later implementation with rt_ehrenfest. changed fragments attribute to be a dictionary holding the fragment mols: mask, instead of having two separate attributes.