### PR TITLE
Ehrenfest restructure

### DIFF
--- a/src/examples/water_dimer_icd.py
+++ b/src/examples/water_dimer_icd.py
@@ -43,14 +43,13 @@ water2.kernel()
 # Calculate noscf basis to print orbital occupations in
 noscf_orbitals = basis_utils.noscfbasis(dimer, water1, water2)
 
-rt_water = rt_scf.RT_SCF(dimer,0.1, 1500)
+rt_water = rt_scf.RT_SCF(dimer,1, 1500)
 # Declare which observables to be calculated/printed
 rt_water.observables.update(energy=True, mo_occ=True, charge=True)
 
 # Create object for complex absorbing potential and add to rt object
-CAP = MOCAP(0.5, 0.0477, 1.0, 10.0, dimer.get_ovlp())
+CAP = MOCAP(0.5, 0.0477, 1.0, 10.0)
 rt_water.add_potential(CAP)
-
 # Remove electron from 4th molecular orbital (in SCF basis)
 # Input the two water fragments for their charge to be calculated
 rt_utils.excite(rt_water, 4)

--- a/src/examples/water_ehrenfest.py
+++ b/src/examples/water_ehrenfest.py
@@ -50,7 +50,7 @@ water2.kernel()
 #noscf_orbitals = basis_utils.noscfbasis(dimer, water1, water2)
 #noscf_orbitals = dimer.mo_coeff
 
-rt_water = rt_ehrenfest.RT_Ehrenfest(dimer, 1, 1000, filename="H2O", prop="magnus_interpol", orth=None, frequency=1, chkfile=None, verbose=3, Ne_step=10, N_step=10)
+rt_water = rt_ehrenfest.RT_Ehrenfest(dimer, 1, 1000, filename='H2O', prop="magnus_interpol", orth=None, frequency=1, chkfile=None, verbose=3, Ne_step=10, N_step=10)
 # Declare which observables to be calculated/printed
 rt_water.observables.update(energy=True, mo_occ=True, charge=True)
 

--- a/src/examples/water_mocap.py
+++ b/src/examples/water_mocap.py
@@ -24,7 +24,7 @@ delta_field = ElectricField('delta', [0.0, 0.0, 0.0001])
 
 rt_mf.prop = 'magnus_interpol'
 
-CAP = MOCAP(1.0, 0.5, 1.0, 100.0, mf.get_ovlp())
+CAP = MOCAP(1.0, 0.5, 1.0, 100.0)
 rt_mf.add_potential(CAP, delta_field)
 
 

--- a/src/rt_cap.py
+++ b/src/rt_cap.py
@@ -7,12 +7,11 @@ Molecular Orbital Complex Absorbing Potential (CAP)
 
 
 class MOCAP:
-    def __init__(self, expconst, emin, prefac=1, maxval=100, thr=1e-7):
+    def __init__(self, expconst, emin, prefac=1, maxval=100):
         self.expconst = expconst
         self.emin = emin
         self.prefac = prefac
         self.maxval = maxval
-        self.thr = thr
 
     def calculate_cap(self, rt_mf, fock):
         # Construct fock_orth without CAP

--- a/src/rt_ehrenfest.py
+++ b/src/rt_ehrenfest.py
@@ -54,12 +54,20 @@ class RT_Ehrenfest(RT_SCF):
 
     def update_mol(self):
         mo_coeff = self._scf.mo_coeff
+        '''
         if self._scf.istype('RKS'): xc = self._scf.xc; self._scf = scf.RKS(self.nuc.get_mol()); self._scf.xc = xc
         elif self._scf.istype('RHF'): self._scf = scf.RHF(self.nuc.get_mol())
         elif self._scf.istype('UKS'): xc = self._scf.xc; self._scf = dft.UKS(self.nuc.get_mol()); self._scf.xc = xc
         elif self._scf.istype('UHF'): self._scf = scf.UHF(self.nuc.get_mol())
         elif self._scf.istype('GKS'): xc = self._scf.xc; self._scf = scf.GKS(self.nuc.get_mol()); self._scf.xc = xc
         elif self._scf.istype('GHF'): self._scf = scf.GHF(self.nuc.get_mol())
+        ''' 
+        if hasattr(self._scf, 'xc'):
+            xc = self._scf.xc
+            self._scf.__init__(self.nuc.get_mol())
+            self._scf.xc = xc
+        else:
+            self._scf.__init__(self.nuc.get_mol())
         self._scf.mo_coeff = mo_coeff
         self._scf.mo_occ = self.occ
         self.ovlp = self._scf.get_ovlp()
@@ -69,13 +77,15 @@ class RT_Ehrenfest(RT_SCF):
         #self.orth = scf.addons.canonical_orth_(self.ovlp)
 
     def update_grad(self):
+        self._grad = self._scf.apply(getattr(grad, type(self._scf).__name__))
+        '''
         if self._scf.istype('RKS'): self._grad = self._scf.apply(grad.RKS)
         elif self._scf.istype('RHF'): self._grad = self._scf.apply(grad.RHF)
         elif self._scf.istype('UKS'): self._grad = self._scf.apply(grad.UKS)
         elif self._scf.istype('UHF'): self._grad = self._scf.apply(grad.UHF)
         elif self._scf.istype('GKS'): self._grad = self._scf.apply(grad.GKS)
         elif self._scf.istype('GHF'): self._grad = self._scf.apply(grad.GHF)
-
+        '''
     # Additinal term arising from the moving nuclei in the classical path approximation to be added to the fock matrix
     # Reminder to turn the complex conserving potential term Omega into one of the rtscf potential classes
     def get_omega(self):

--- a/src/rt_integrators.py
+++ b/src/rt_integrators.py
@@ -13,6 +13,9 @@ def magnus_step(rt_mf):
 
     fock_orth = rt_mf.get_fock_orth(rt_mf.den_ao)
 
+    # Update time, mol is updated here if rt_mf is Ehrenfest obj
+    rt_mf.update_time()
+
     u = expm(-1j*2*rt_mf.timestep*fock_orth)
 
     mo_coeff_orth_new = np.matmul(u, rt_mf.mo_coeff_orth_old)
@@ -34,6 +37,9 @@ def magnus_interpol(rt_mf):
 
     mo_coeff_orth = rt_mf.rotate_coeff_to_orth(rt_mf._scf.mo_coeff)
     fock_orth_p12dt = 2 * rt_mf._fock_orth - rt_mf._fock_orth_n12dt
+    
+    # Update time, mol is updated here if rt_mf is an Ehrenfest obj
+    rt_mf.update_time()
 
     for iteration in range(rt_mf.magnus_maxiter):
         u = expm(-1j*rt_mf.timestep*fock_orth_p12dt)
@@ -71,6 +77,10 @@ def rk4(rt_mf):
     '''
 
     fock_orth = rt_mf.get_fock_orth(rt_mf.den_ao)
+    
+    # Update time, mol is updated here if rt_mf is Ehrenfest obj
+    rt_mf.update_time()
+
     mo_coeff_orth = rt_mf.rotate_coeff_to_orth(rt_mf._scf.mo_coeff)
 
     # k1
@@ -89,7 +99,7 @@ def rk4(rt_mf):
     k4 = -1j * rt_mf.timestep * (np.matmul(fock_orth,mo_coeff_orth_3))
 
     mo_coeff_orth_new = mo_coeff_orth + (k1/6 + k2/3 + k3/3 + k4/6)
-    mo_coeff_ao_new = rt_mf.rotate_coeff(mo_coeff_orth_new, 'MO->AO')
+    mo_coeff_ao_new = rt_mf.rotate_coeff_to_ao(mo_coeff_orth_new)
 
     rt_mf._scf.mo_coeff = mo_coeff_ao_new
     rt_mf.den_ao = rt_mf._scf.make_rdm1(mo_occ=rt_mf.occ)

--- a/src/rt_observables.py
+++ b/src/rt_observables.py
@@ -1,6 +1,7 @@
 import numpy as np
 import rt_output
 from basis_utils import read_mol
+from rt_utils import update_fragments
 
 '''
 Real-time Observable Functions
@@ -35,6 +36,8 @@ def _remove_suppressed_observables(rt_mf):
             del rt_mf._observables_functions[key]
 
 def get_observables(rt_mf):
+    if rt_mf.istype('RT_Ehrenfest'):
+        update_fragments(rt_mf)
     for key, function in rt_mf._observables_functions.items():
           function[0](rt_mf, rt_mf.den_ao)
 
@@ -64,6 +67,14 @@ def get_charge(rt_mf, den_ao):
     
     rt_mf._charge = charge
 
+def get_dipole(rt_mf, den_ao):
+    dipole = []
+    dipole.append(rt_mf._scf.dip_moment(rt_mf._scf.mol, rt_mf.den_ao,'A.U.', 1))
+    for frag, mask in rt_mf.fragments.items():
+        dipole.append(frag.dip_moment(frag.mol, den_ao[mask], 'A.U.', 1))
+    
+    rt_mf._dipole = dipole
+
 def get_mo_occ(rt_mf, den_ao):
     # P_mo = C+SP_aoSC
     SP_aoS = np.matmul(rt_mf.ovlp,np.matmul(den_ao,rt_mf.ovlp))
@@ -76,14 +87,6 @@ def get_mo_occ(rt_mf, den_ao):
         den_mo = np.real(den_mo)
 
     rt_mf._mo_occ = np.diagonal(den_mo)
-
-def get_dipole(rt_mf, den_ao):
-    dipole = []
-    dipole.append(rt_mf._scf.dip_moment(rt_mf._scf.mol, rt_mf.den_ao,'A.U.', 1))
-    for frag, mask in rt_mf.fragments.items():
-        dipole.append(frag.dip_moment(frag.mol, den_ao[mask], 'A.U.', 1))
-    
-    rt_mf._dipole = dipole
 
 def get_mag(rt_mf, den_ao):
     mag = [] 

--- a/src/rt_prop.py
+++ b/src/rt_prop.py
@@ -2,53 +2,13 @@ import numpy as np
 import rt_integrators
 import rt_observables
 import rt_output
-from rt_utils import update_chkfile, update_fragments
-from ehrenfest_force import get_force
+from rt_utils import update_chkfile
 
 '''
-Real-time Propagation Loops
+Real-time Propagation
 '''
 
-def scf_propagate(rt_scf, mo_coeff_print):
-    prop_init(rt_scf, mo_coeff_print)
-    for i in range(0, int(rt_scf.max_time / rt_scf.timestep)):
-        if np.mod(i, rt_scf.frequency) == 0:
-            rt_observables.get_observables(rt_scf)
-            if rt_scf.chkfile is not None:
-                update_chkfile(rt_scf)
-
-        rt_scf._integrate_function(rt_scf)
-        rt_scf.current_time += rt_scf.timestep
-
-    rt_observables.get_observables(rt_scf)  # Collect observables at final time
-    if rt_scf.chkfile is not None:
-        update_chkfile(rt_scf)
-
-def ehrenfest_propagate(rt_ehrenfest, mo_coeff_print):
-    prop_init(rt_ehrenfest, mo_coeff_print)
-    #for i in range(0, self.N_step * self.Ne_step * int(self.max_time / self.timestep)):
-    for i in range(0, int(rt_ehrenfest.max_time / rt_ehrenfest.timestep)):
-        #if np.mod(i, self.N_step * self.Ne_step * self.frequency) == 0:
-        if np.mod(i, rt_ehrenfest.frequency) == 0:
-            update_fragments(rt_ehrenfest)
-            rt_observables.get_observables(rt_ehrenfest)
-            if rt_ehrenfest.chkfile is not None:
-                update_chkfile(rt_ehrenfest)
-
-        rt_ehrenfest._integrate_function(rt_ehrenfest)
-        rt_ehrenfest.current_time += rt_ehrenfest.timestep
-        if np.mod(i, rt_ehrenfest.N_step * rt_ehrenfest.Ne_step) == 0:
-            rt_ehrenfest.nuc.get_vel(-0.5 * rt_ehrenfest.N_step * rt_ehrenfest.Ne_step * rt_ehrenfest.timestep)
-            rt_ehrenfest.nuc.force = get_force(rt_ehrenfest)
-            rt_ehrenfest.nuc.get_vel(-0.5 * rt_ehrenfest.N_step * rt_ehrenfest.Ne_step * rt_ehrenfest.timestep)
-
-    update_fragments(rt_ehrenfest)
-    rt_observables.get_observables(rt_ehrenfest)  # Collect observables at final time
-    if rt_ehrenfest.chkfile is not None:
-        update_chkfile(rt_ehrenfest)
-
-
-def prop_init(rt_mf, mo_coeff_print):
+def propagate(rt_mf, mo_coeff_print):
     if mo_coeff_print is None:
             if hasattr(rt_mf, 'mo_coeff_print'):
                 pass
@@ -67,3 +27,17 @@ def prop_init(rt_mf, mo_coeff_print):
         rt_mf._fock_orth_n12dt = rt_mf.get_fock_orth(rt_mf.den_ao)
         if not hasattr(rt_mf, 'magnus_tolerance'): rt_mf.magnus_tolerance = 1e-7
         if not hasattr(rt_mf, 'magnus_maxiter'): rt_mf.magnus_maxiter = 15
+
+    # Start propagation
+    for i in range(0, int(rt_mf.max_time / rt_mf.timestep)):
+        if np.mod(i, rt_mf.frequency) == 0:
+            rt_observables.get_observables(rt_mf)
+            if rt_mf.chkfile is not None:
+                update_chkfile(rt_mf)
+
+        rt_mf._integrate_function(rt_mf)
+
+    rt_observables.get_observables(rt_mf)  # Collect observables at final time
+    if rt_mf.chkfile is not None:
+        update_chkfile(rt_mf)
+

--- a/src/rt_utils.py
+++ b/src/rt_utils.py
@@ -63,6 +63,7 @@ def update_fragments(rt_mf):
     rt_mf.mo_coeff_print = mf_new.mo_coeff
 
 def restart_from_chkfile(rt_mf):
+    rt_mf._log.note(f'Restarting from chkfile: {rt_mf.chkfile}.')
     with open(rt_mf.chkfile, 'r') as f:
         chk_lines = f.readlines()
         rt_mf.current_time = float(chk_lines[0].split()[3])

--- a/src/rt_utils.py
+++ b/src/rt_utils.py
@@ -46,7 +46,6 @@ def update_fragments(rt_mf):
         elif rt_mf._scf.istype('UHF'): frag_new = scf.UHF(frag_mol)
         elif rt_mf._scf.istype('GKS'): frag_new = scf.GKS(frag_mol); frag_new.xc = frag_old.xc
         elif rt_mf._scf.istype('GHF'): frag_new = scf.GHF(frag_mol)
-        print('a')
         frag_new.kernel() 
         fragments.append(frag_new)
     input_fragments(rt_mf, *fragments)
@@ -58,6 +57,8 @@ def update_fragments(rt_mf):
     elif rt_mf._scf.istype('UHF'): mf_new = scf.UHF(rt_mf._scf.mol)
     elif rt_mf._scf.istype('GKS'): mf_new = scf.GKS(rt_mf._scf.mol); mf_new.xc = rt_mf._scf.xc
     elif rt_mf._scf.istype('GHF'): mf_new = scf.GHF(rt_mf._scf.mol)
+    
+    ### ?
     mf_new.kernel() 
     #rt_mf.mo_coeff_print = noscfbasis(mf_new, *fragments)
     rt_mf.mo_coeff_print = mf_new.mo_coeff


### PR DESCRIPTION
Added update_time() method.
rt_scf and rt_ehrenfest share same kernel and same propagate function
Replaced if...elif loops with __init__ call for reinstantiating mf, and replaced if..elif loops with getattr call for updating gradient object.